### PR TITLE
add NoAdjacentSymbolSpace config option

### DIFF
--- a/html2text.go
+++ b/html2text.go
@@ -19,8 +19,8 @@ type Options struct {
 	PrettyTablesOptions *PrettyTablesOptions // Configures pretty ASCII rendering for table elements.
 	OmitLinks           bool                 // Turns on omitting links
 
-	// NoAdjacentSymbolSpace specifies that you do not want strings which start
-	// and end with symbols to have spaces next to adjacent elements.
+	// NoAdjacentSymbolSpace specifies that you do not want strings  end with
+	// symbols to have spaces next to adjacent elements.
 	// This is helpful when sanitizing html displaying as query parameters.
 	NoAdjacentSymbolSpace bool
 }
@@ -129,12 +129,12 @@ type textifyTraverseContext struct {
 	options       Options
 	endsWithSpace bool
 
-	// endsWithSymbol is useful for detecting query params.
-	endsWithSymbol  bool
-	justClosedDiv   bool
-	blockquoteLevel int
-	lineLength      int
-	isPre           bool
+	// endsWithQuerySymbol is useful for detecting query params.
+	endsWithQuerySymbol bool
+	justClosedDiv       bool
+	blockquoteLevel     int
+	lineLength          int
+	isPre               bool
 }
 
 // tableTraverseContext holds table ASCII-form related context.
@@ -440,10 +440,10 @@ func (ctx *textifyTraverseContext) emit(data string) error {
 	for _, line := range lines {
 		runes := []rune(line)
 		startsWithSpace := unicode.IsSpace(runes[0])
-		isOnlySymbol := len(data) == 1 && QuerySymbols.MatchString(data) &&
+		isOnlyQuerySymbol := len(data) == 1 && QuerySymbols.MatchString(data) &&
 			ctx.options.NoAdjacentSymbolSpace
 		if !startsWithSpace && !ctx.endsWithSpace &&
-			!strings.HasPrefix(data, ".") && !(isOnlySymbol || ctx.endsWithSymbol) {
+			!strings.HasPrefix(data, ".") && !(isOnlyQuerySymbol || ctx.endsWithQuerySymbol) {
 			if err = ctx.buf.WriteByte(' '); err != nil {
 				return err
 			}
@@ -453,7 +453,7 @@ func (ctx *textifyTraverseContext) emit(data string) error {
 
 		// We want to ensure we're not incorrectly writing spaces around query
 		// params.
-		ctx.endsWithSymbol = QuerySymbols.MatchString(string(data[len(data)-1])) &&
+		ctx.endsWithQuerySymbol = QuerySymbols.MatchString(string(data[len(data)-1])) &&
 			ctx.options.NoAdjacentSymbolSpace
 		for _, c := range line {
 			if _, err = ctx.buf.WriteString(string(c)); err != nil {

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -470,10 +470,6 @@ func TestLinks(t *testing.T) {
 			"<a href=\"http://www.google.com\" >http://www.google.com</a>",
 			`http://www.google.com`,
 		},
-		{
-			"&amp;<a href='mailto:contact@example.org'>Contact Us</a>",
-			`&Contact Us ( contact@example.org )`,
-		},
 	}
 
 	for _, testCase := range testCases {
@@ -485,7 +481,7 @@ func TestLinks(t *testing.T) {
 	}
 }
 
-func TestNoAmpSpace(t *testing.T) {
+func TestNoAdjacentSymbolSpace(t *testing.T) {
 	testCases := []struct {
 		input  string
 		output string
@@ -494,10 +490,18 @@ func TestNoAmpSpace(t *testing.T) {
 			"&amp;<a href='mailto:contact@example.org'>Contact Us</a>",
 			`&Contact Us ( contact@example.org )`,
 		},
+		{
+			"&amp;<a href='mailto:email=contact@example.org'>email=Contact Us</a>",
+			`&email=Contact Us ( email=contact@example.org )`,
+		},
+		{
+			"&amp;email=<a href='mailto:contact@example.org'>Contact Us</a>",
+			`&email=Contact Us ( contact@example.org )`,
+		},
 	}
 
 	for _, testCase := range testCases {
-		if msg, err := wantString(testCase.input, testCase.output, Options{NoAmpSpace: true}); err != nil {
+		if msg, err := wantString(testCase.input, testCase.output, Options{NoAdjacentSymbolSpace: true}); err != nil {
 			t.Error(err)
 		} else if len(msg) > 0 {
 			t.Log(msg)

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -87,6 +87,10 @@ func TestStrippingWhitespace(t *testing.T) {
 			"test&nbsp;&nbsp;&nbsp; text&nbsp;",
 			"test    text",
 		},
+		{
+			"&amp;test",
+			"&test",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -142,6 +146,10 @@ func TestParagraphsAndBreaks(t *testing.T) {
 		{
 			"<pre>test1\ntest 2\n\ntest  3</pre>",
 			"test1\ntest 2\n\ntest  3",
+		},
+		{
+			"<pre>&amp;test1\ntest 2\n\ntest  3</pre>",
+			"&test1\ntest 2\n\ntest  3",
 		},
 	}
 
@@ -462,10 +470,34 @@ func TestLinks(t *testing.T) {
 			"<a href=\"http://www.google.com\" >http://www.google.com</a>",
 			`http://www.google.com`,
 		},
+		{
+			"&amp;<a href='mailto:contact@example.org'>Contact Us</a>",
+			`&Contact Us ( contact@example.org )`,
+		},
 	}
 
 	for _, testCase := range testCases {
 		if msg, err := wantString(testCase.input, testCase.output); err != nil {
+			t.Error(err)
+		} else if len(msg) > 0 {
+			t.Log(msg)
+		}
+	}
+}
+
+func TestNoAmpSpace(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{
+			"&amp;<a href='mailto:contact@example.org'>Contact Us</a>",
+			`&Contact Us ( contact@example.org )`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		if msg, err := wantString(testCase.input, testCase.output, Options{NoAmpSpace: true}); err != nil {
 			t.Error(err)
 		} else if len(msg) > 0 {
 			t.Log(msg)


### PR DESCRIPTION
## What
Adds a config option to not pad spaces next to common query param symbols.

## Why
Fixes issues we see when stripping the HTML from responses sent by Threads.

## Testing
automated